### PR TITLE
feat: (wip) add metanorma "shell" document

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,11 @@
+---
+name: Bug Report
+about: Perform some action within the repository that may or may not involve code
+  changes.
+title: "[Bug Report] <insert task name>"
+labels: task
+assignees: prasaanth-verses
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,26 @@
+---
+name: Discussion
+about: Discuss a concern with the working group.
+title: "[DISCUSSION] <Insert Title Here>"
+labels: needs discussion
+assignees: ''
+
+---
+
+## What is the title of the document that you would like to discuss?
+Please specify title of the document that you would like to discuss. Ex. IEEEP2874-D2.pdf
+
+## Copy the text that you would like to discuss
+Please copy the entire body of the text that you would like to discuss for reference.
+
+## Describe the problem or concern you'd like to discuss
+A clear and concise description of your concern.
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## (Optional) Describe alternatives you've considered
+A clear and concise description of any alternative solutions.
+
+## (Optional) Additional context
+Add any other context or screenshots.

--- a/.github/ISSUE_TEMPLATE/issue-with-tool.md
+++ b/.github/ISSUE_TEMPLATE/issue-with-tool.md
@@ -1,0 +1,10 @@
+---
+name: Issue with Tool
+about: Describe this issue template's purpose here.
+title: "[TOOL]"
+labels: ''
+assignees: prasaanth-verses
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/issue-with-udg.md
+++ b/.github/ISSUE_TEMPLATE/issue-with-udg.md
@@ -1,0 +1,13 @@
+---
+name: Issue with UDG
+about: Use this issue type if you're seeking to make a change in `sources/`.
+title: "[UDG] <Insert Title Here>"
+labels: ''
+assignees: ''
+
+---
+
+## Problem Summary
+
+## Proposed Change
+<!-- Text to be inserted -->

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,29 @@
+# Workflows
+
+## nightly_cleanup.yml
+
+The required token environment variable provided from the secret `secrets.DELETE_ARTIFACTS_PAT` needs to have the following access requirements:
+
+- `repo`
+  - `repo:status`
+  - `repo_deployment`
+  - `public_repo`
+  - `repo:invite`
+  - `security_events`
+
+FIXME: It may not require all of the access requirements shown above. Clean this up at a future point in time.
+
+## post_status_report.yml
+
+The required token environment variable provided from the secret `secrets.REPO_STATUS_ACTION` needs to have the following access requirements:
+
+- `repo`
+  - `repo:status`
+  - `repo_deployment`
+  - `public_repo`
+  - `repo:invite`
+  - `security_events`
+- `write:discussion`
+  - `read:discussion`
+
+FIXME: It may not require all of the access requirements shown above. Clean this up at a future point in time.

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,33 @@
+name: generate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref_name }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: metanorma/metanorma:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache Metanorma assets
+        uses: actions-mn/cache@v1
+
+      - name: Print Metanorma version
+        run: metanorma --version
+
+      - name: Metanorma generate site
+        uses: actions-mn/build-and-publish@v2
+        with:
+          agree-to-terms: true
+          destination: artifact
+          artifact-name: draft

--- a/.github/workflows/nightly_cleanup.yml
+++ b/.github/workflows/nightly_cleanup.yml
@@ -1,0 +1,13 @@
+name: "nightly artifacts cleanup"
+on:
+  schedule:
+    - cron: "0 4 * * *" # every night at 12 AM EST or 4 am UTC
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.DELETE_ARTIFACTS_PAT }}
+          expire-in: 1d # Set this to 0 to delete all artifacts

--- a/.github/workflows/post_all_hands_discussion.yml
+++ b/.github/workflows/post_all_hands_discussion.yml
@@ -1,0 +1,32 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: post all hands discussion
+
+on:
+  workflow_dispatch:
+
+jobs:
+  post_discussion:
+    defaults:
+      run:
+        working-directory: tools/create-all-hands-discussion
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run
+        run: cargo run
+        env:
+          GITHUB_TOKEN: ${{ secrets.CREATE_ALL_HANDS_DISCUSSION_ACTION }}

--- a/.github/workflows/post_status_report.yml
+++ b/.github/workflows/post_status_report.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: post status report
+
+on:
+  workflow_dispatch:
+
+jobs:
+  post_discussion:
+    defaults:
+      run:
+        working-directory: tools/repo-status
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: tools/repo-status
+      - run: npm ci
+      - run: npm start
+        env:
+          token: ${{ secrets.REPO_STATUS_ACTION }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'metanorma-cli'

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -1,0 +1,9 @@
+---
+metanorma:
+  source:
+    files:
+      - sources/document.adoc
+
+  collection:
+    name: IEEE Pnnnn
+    organization: Spatial Web Foundation / IEEE

--- a/sources/copyright.adoc
+++ b/sources/copyright.adoc
@@ -1,0 +1,14 @@
+== copyright-statement
+=== {blank}
+
+IEEE SA Industry Affiliate Network (IAN) base specification contributed by Spatial Web Foundation.
+
+&#xa0;
+
+[[copyright]]
+[align="left"]
+Copyright © {{ docyear }} by The Institute of Electrical and Electronics Engineers, Inc. +
+Three Park Avenue +
+New York, New York 10016-5997, USA
+
+All rights reserved.

--- a/sources/document.adoc
+++ b/sources/document.adoc
@@ -1,0 +1,66 @@
+= Universal Domain Graph (UDG) Design
+:title: IEEE Draft Standard for Universal Domain Graph (UDG) Design
+:docnumber: 9999
+:doctype: standard
+:docstage: approved
+:revdate: 2026-01-01
+:issued-date: 2026-08-15
+:ieee-sasb-approved-date: 2026-05-28
+:copyright-year: 2026
+:language: en
+:edition: 1
+:society: Computer Society
+:committee: Artificial Intelligence Standards Committee
+:working-group: Spatial Web Working Group
+:keywords: HSML, HSTP, Hyperspace Modelling Language, Hyperspace Transaction Protocol, IEEE 9999™, Spatial Web, Spatial Web identifier, SWID, UDG, Universal Domain Graph, verifiable credentials, W3C decentralized identifier (DIDs)
+:isbn-pdf: 979-8-XXXX-XXXX-X
+:stdid-pdf: STDXXXXX
+:isbn-print: 979-8-XXXX-XXXX-X
+:stdid-print: STDPDXXXXX
+:imagesdir: images
+:mn-document-class: ieee
+:mn-output-extensions: xml,html,doc,rxl,pdf
+:local-cache-only:
+:toc-figures: true
+:toc-tables: true
+:boilerplate-authority: copyright.adoc
+
+// 20250319 rwp override background colors for admonitions in the current document
+// based on ticket
+// https://github.com/Spatial-Web-Foundation/SWF-Corpus_and_IEEEP2874/issues/1822
+//
+// and fix
+// https://github.com/metanorma/metanorma-ieee/issues/464
+
+== Metanorma-Extension
+
+=== user-css
+
+[source]
+----
+.Note, .note { background-color: white}
+.Admonition { background-color: white}
+.example { background-color: white}
+----
+
+
+include::sections/00-participants.adoc[]
+
+include::sections/00-abstract.adoc[]
+
+include::sections/00-introduction.adoc[]
+
+include::sections/01-overview.adoc[]
+
+include::sections/02-normrefs.adoc[]
+
+include::sections/03-terms.adoc[]
+
+// include::sections/04-spatial_web_standards.adoc[]
+
+include::sections/05-building-blocks.adoc[]
+
+include::sections/annex-bibliography.adoc[]
+
+include::sections/annex-swf_authors_reviewers.adoc[]
+

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,0 +1,5 @@
+
+[abstract]
+== Abstract
+
+TBD.

--- a/sources/sections/00-introduction.adoc
+++ b/sources/sections/00-introduction.adoc
@@ -1,0 +1,14 @@
+== Introduction
+
+TBD.
+
+[.preface]
+== Acknowledgements
+
+Material from the Spatial Web Foundation Spatial Web Protocol, Architecture and
+Governance, Version D3.3, copyright (c) 2025 Spatial Web Foundation, was used as
+under license from the Spatial Web Foundation.
+
+The definitions from ISO are used with permission of the American National
+Standards Institute (ANSI) on behalf of the International Organization for
+Standardization. All rights reserved.

--- a/sources/sections/00-participants.adoc
+++ b/sources/sections/00-participants.adoc
@@ -1,0 +1,200 @@
+
+== Participants
+
+// rwp 20230607 #688 indicates there is a duplication of "Working Group"
+// somewhere on this page; if it is not coming through here, then it must be
+// in the metanorma IEEE template;  i will check the generated files and go
+// from there.
+
+=== Working group
+
+item::
+name::: Gabriel René
+role::: Chair
+item::
+name::: George Percivall
+role::: Vice Chair
+item::
+name::: Christine Perey
+role::: Secretary, Technical Editor
+item::
+name::: Prasaanth Sridharan
+role::: Technical Editor
+
+item:: Mahault Albarracin
+item:: Nicolás Andrés Hinrichs
+item:: Daniel Ari Friedman
+item:: Ismail Arribas
+item:: Flores Bakker
+item:: Bert Berkers
+item:: Christopher Buckley
+item:: Darin Bunker
+item:: John Carenbauer
+item:: Edward Chow
+item:: Axel Constant
+item:: Jessica Covington
+item:: Steve Coy
+item:: John Daly
+item:: Miguel de Prado Escudero
+item:: Bastiaan den Braber
+item:: Geert Devos
+item:: Cauê Dias Silva
+item:: Susan Dickey
+item:: Dave Douglass
+item:: Marc Duranton
+item:: Aidin Eslami
+item:: Jason Fox
+item:: Karl Friston
+item:: Stefan Fritsch
+item:: Kaiser Fung
+item:: Linda Goetze
+item:: Jay Graver
+item:: Dennis Hahn
+item:: James Hendrickson
+item:: Brian Hicks
+item:: Tony Hodgson
+item:: Denise Holt
+item:: Jacqueline Hynes
+item:: Paul Jones
+item:: Mo Kalby
+item:: Alex Kiefer
+item:: Susie Kim
+item:: Sebastian King
+item:: John Kittleson
+item:: Greg Kluthe
+item:: Andrew Knight
+item:: Martin Laskowski
+item:: Brandon Lucht
+item:: Forrist Lytehaause
+item:: Quinn Madson
+item:: Guido Magliano
+item:: Sarah Grace Manski
+item:: Dan Mapes
+item:: Joshua Martinez
+item:: Panayotis Mavromatis
+item:: Michael McCool
+item:: Don Moody
+item:: Alessandro Muzzi
+item:: Gyu Myoung Lee
+item:: Sanjeev Namjoshi
+item:: Greg Nutt
+item:: Aza O'Leary
+item:: Chris O'Neill
+item:: Capm Petersen
+item:: Richard Petty
+item:: Reese Plews
+item:: Maxwell Ramstead
+item:: Dan Richardson
+item:: Nora Rusin
+item:: Lior Saar
+item:: Kasra Sabery
+item:: Shoichi Sakane
+item:: Mikel Salazar
+item:: Tim Sandgren
+item:: Philippe Sayegh
+item:: Benjamin Schlup
+item:: Johan Schotte
+item:: David Scott Carroll
+item:: Bill Seely
+item:: Jon Seneger
+item:: Dyci Sfregola
+item:: Kirpal Singh Khalsa
+item:: Dmitri Smirnov
+item:: Steve Smyth
+item:: Cédric Sounard
+item:: Joel Spielberger
+item:: Toby St. Clere Smithe
+item:: Debi Stack
+item:: Sara Summers
+item:: Steven Swanson
+item:: Hari Thiruvengada
+item:: Alexander Tschantz
+item:: Venkatesh Venkataramanujam
+item:: Tim Verbelen
+item:: Jan-Erik Vinje
+item:: Michael Wadden
+item:: Mike Warner
+item:: Grant Wood
+item:: Ryan Zaki
+item:: Gontran Zepeda
+
+
+
+=== Balloting group
+
+item:: Hana Abdulla
+item:: Boon Chong Ang
+item:: Amir Reza Asadi
+item:: Riccardo Brama
+item:: David Carroll
+item:: Bastiaan den Braber
+item:: Susan Dickey
+item:: Marc Duranton
+item:: Karl Friston
+item:: Madhukar Gaganam
+item:: Marco Hernandez
+item:: Werner Hoelzl
+item:: Denise Holt
+item:: Jacqueline Hynes
+item:: Piotr Karocki
+item:: Siri Jodha Khalsa
+item:: Alex Kiefer
+item:: Greg Kluthe
+item:: T. Leopold
+item:: Yuzhuo Li
+item:: Daozhuang Lin
+item:: Xin Ma
+item:: Sarah Grace Manski
+item:: Dan Mapes
+item:: LaMont McAliley
+item:: Arumugam Paventhan
+item:: Capm Petersen
+item:: Reese Plews
+item:: R. K. Rannow
+item:: Philippe Sayegh
+item:: Benjamin Schlup
+item:: Reinhard Schrage
+item:: Jhony Sembiring
+item:: Toby St. Clere Smithe
+item:: Alexander Tschantz
+item:: Michael Wadden
+item:: Lisa Ward
+item:: Grant Wood
+
+=== Standards board
+
+item::
+name::: Lei Wang
+role::: Chair
+item::
+name::: Jon Walter Rosdahl
+role::: Vice Chair
+item::
+name::: David J. Law
+role::: Past Chair
+item::
+name::: Alpesh Shah
+role::: Secretary
+
+item:: Edward Au
+item:: Ted Burse
+item:: Xiaofeng (Alfred) Chen
+item:: Doug Edwards
+item:: Nehad El-Sherif
+item:: J. Travis Griffith
+item:: Deborah R. Hagar
+item:: Guido R. Hiertz
+item:: Ronald W. Hotchkiss
+item:: Tyler L. Jaynes
+item:: Thomas Koshy
+item:: Howard Li
+item:: Xiaohui Liu
+item:: Kevin W. Lu
+item:: Hiroshi Mano
+item:: Daleep C. Mohla
+item:: Annette D. Reilly
+item:: Robby Robson
+item:: Daniel Sabin
+item:: F. Keith Waters
+item:: Sha Wei
+item:: Luyang (Eric) Zhang

--- a/sources/sections/01-overview.adoc
+++ b/sources/sections/01-overview.adoc
@@ -1,0 +1,30 @@
+== Overview
+
+=== Scope
+
+TBD.
+
+=== Purpose
+
+TBD.
+
+=== Structure of document
+
+TBD.
+
+This document is structured as a reference model consistent with the approach defined in <<ISO_IEC_IEEE_42010_2022>>. This reference model provides concepts to subsequently define Spatial Web Implementation standards and to guide domain-specific Spatial Web architecture developments.
+
+This document provides three viewpoints of the Spatial Web as an abstract system:
+
+<<section-value-for-stakeholders,Value for stakeholders>> (<<section-value-for-stakeholders>>)
+
+<<section-knowledge-modeling,Knowledge modeling>> (<<section-knowledge-modeling>>)
+
+<<section-distributed-computing,Distributed computing>> (<<section-distributed-computing>>)
+
+
+Several views are provided for each viewpoint, e.g., in the Knowledge Modeling viewpoint, the <<section-hyperspace,Hyperspace>> subclause (<<section-hyperspace>>) is a view of spatial models used in the Spatial Web.
+
+=== Conventions used in this standard
+
+In this document the following Spatial Web ontology entries (ENTITY, ACTIVITY, AGENT, CONTRACT, CHANNEL, CREDENTIAL, DOMAIN, HYPERSPACE, and TIME) are represented using uppercase.

--- a/sources/sections/02-normrefs.adoc
+++ b/sources/sections/02-normrefs.adoc
@@ -1,0 +1,21 @@
+
+[bibliography]
+== Normative references
+
+* [[[IEC_SRD_63188_2022,IEC SRD 63188]]]
+* [[[IEEE_2413_2019,IEEE Std 2413]]]
+* [[[IEEE_7007_2021,IEEE Std 7007-2021]]]
+* [[[ISO_19125-1_2004,ISO 19125-1]]]
+* [[[ISO_IEC_20802_1_2016,(ISO/IEC 20802-1 footnote:[ISO publications are available from the International Organization for Standardization (https://www.iso.org/) and the American National Standards Institute (https://www.ansi.org/).] footnote:[IEC publications are available from the International Electrotechnical Commission (https://www.iec.ch) and the American National Standards Institute (https://www.ansi.org/).])ISO/IEC 20802-1]]]
+* [[[ISO_IEC_20802_2_2016,ISO/IEC 20802-2]]]
+* [[[http2_rfc,IETF RFC 9113]]]
+* [[[mqtt_v5, (OASIS mqtt-v5.0 footnote:[OASIS publications are available from the Organization for the Organization for the Advancement of Structured Information Standards (http://www.oasis-open.org).])mqtt-v5.0]]]
+* [[[ogc_geopose,OGC 21-056r11]]], OGC GeoPose 1.0 Data Exchange Standard
+* [[[w3c_json_ld,W3C json-ld11]]], A JSON-based Serialization for Linked Data
+
+* [[[h3geo,1]]],
+span:organization[Uber Technologies, Inc.]
+span:title[H3: Hexagonal hierarchical geospatial indexing system]
+span:type[website]
+span:date[2024]
+span:uri[https://h3geo.org]

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,0 +1,122 @@
+== Definitions, acronyms and abbreviations
+
+
+=== Definitions
+
+==== ACTIVITY
+
+A partially ordered set of changes effected by an AGENT.
+
+[type=license]
+NOTE: Notes in text, tables, and figures of a standard are given for information only and do not contain requirements needed to implement this standard.
+
+NOTE: Attributes of an ACTIVITY can be represented using HYPERSPACE Entities.
+
+NOTE: An ACTIVITY can be near-instantaneous or temporally extended and exists as either planned, ongoing, failed, or completed.
+
+NOTE: ACTIVITIES are performed on, by, in, or with, DOMAINS, including other AGENTS.
+
+
+==== AGENT
+
+An ENTITY that senses, responds, and maintains a model of its environment, while performing ACTIVITIES to achieve its goals.
+
+NOTE: AGENT is a type of DOMAIN.
+
+==== artificial intelligence
+
+preferred:[AI]
+
+The capacity of computers or other machines to exhibit or simulate intelligent behavior.
+
+[.source]
+<<IEEE_7010_2020>>
+
+
+==== cloud computing
+
+Paradigm for enabling network access to a scalable and elastic-pool of shareable physical or virtual resources with self-service provisioning and administration on-demand.
+
+[type=license]
+NOTE: (C)ISO. This material is from ISO/IEC 22123-1:2023 with permission of the American National Standards Institute (ANSI) on behalf of the International Organization for Standardization. All rights reserved.
+
+[.source]
+<<ISO_IEC_22123_1_2023,clause=3.1.1>>, Notes to entry have been removed.
+
+==== commons
+The resources of a community that are or ought to be collectively held, managed, shared and made accessible to all members of that community, thus balancing individual needs with sustainability and preservation.
+
+NOTE: Commons encapsulates the concepts of collective stewardship and mutual responsibility, where the community members have both the right to benefit from the resources and the duty to maintain them.
+
+NOTE: Based on concepts from <<mcginnis_dp_for_glo_comm>>.
+
+related:seealso[global commons]
+
+==== cooperation
+The process of working or acting together for common interests and values based on agreement.
+
+NOTE: The organizations agree by contract or by other arrangements to contribute with their resources to the incident response but keep independence concerning their internal hierarchical structure.
+
+[type=license]
+NOTE: (C)ISO. This material is from ISO 22300:2021 with permission of the American National Standards Institute (ANSI) on behalf of the International Organization for Standardization. All rights reserved.
+
+[.source]
+<<ISO_22300_2021,clause=3.1.52>>
+
+==== decentralized identifier
+
+[%metadata]
+abbreviation-type:: initialism
+
+preferred:[DID]
+
+Identifier in the format of the W3C Decentralized Identifier.
+
+[type=license]
+NOTE: Information on references can be found in Clause 2.
+
+NOTE: Adapted from <<w3c_did>>.
+
+
+==== global commons
+Global level {{commons}} that are shared by humanity.
+
+[example] The atmosphere and climate system, biodiversity, critical biomes, and the Internet are examples of global commons.
+
+NOTE: Based on concepts from <<mcginnis_dp_for_glo_comm>>.
+
+related:seealso[commons]
+
+
+=== Acronyms and abbreviations
+
+AI:: artificial intelligence
+API:: application programming interface
+AR:: augmented reality
+BFO:: basic formal ontology
+CRS:: coordinate reference system
+CRUD:: create, read, update, and delete
+DGGS:: Discrete Global Grid System
+DLT:: distributed ledger technology
+FAIR:: Findable, Accessible, Interoperable, and Reusable
+glTF:: GL Transmission Format
+IIC:: Industry IoT Consortium
+IoT:: Internet of Things
+M2M:: machine to machine
+MIME:: Multipurpose Internet Mail Extensions
+OGC:: Open Geospatial Consortium
+OWL:: Web Ontology Language
+RDF:: Resource Description Framework
+SHACL:: Shapes Constraint Language
+SKOS:: Simple Knowledge Organization System
+SPARQL:: SPARQL Protocol and RDF Query Language
+SWE:: Sensor Web Enablement
+UDG:: Universal Domain Graph
+UDT:: Urban Digital Twin
+VC:: verifiable credentials
+VR:: virtual reality
+W3C:: World Wide Web Consortium
+WoT:: Web of Things
+XR:: collective reference to both AR and VR
+ZKP:: zero-knowledge proof
+

--- a/sources/sections/04-spatial_web_standards.adoc
+++ b/sources/sections/04-spatial_web_standards.adoc
@@ -1,0 +1,4 @@
+[[section-spatial-web-standards]]
+== Spatial web standards
+
+TBD.

--- a/sources/sections/05-01-entities.adoc
+++ b/sources/sections/05-01-entities.adoc
@@ -1,0 +1,19 @@
+=== Entities
+
+An **entity** is the fundamental class within the UDG for describing the various things, agents, and places that make up the Spatial Web. Every structure, building, planet, character (agent), animal, mystical alien pyramid or similar construct, is ultimately an entity, and is addressable within the context of the spatial web.
+
+An entity exists within the context of a <<domain>>, where a domain can be thought of as an area of concern in which things happen. While this may (and most likely will) be a physical construct, it doesn't necessarily have to be.
+
+An entity is a spatial web representation of a thing. Internally this entity is represented as a graph of information that describes its identifier, changing in response to changes in its environment (the domain graph in which it resides, which is composed of the graphs of other entities in that system).
+
+There are a specific set of attributes which are required for the entity. Specifically, an entity must have:
+
+* a __spatial web identifier__ or __SWID__, a form of decentralized identifier that can be used to identify the entity uniquely within the broader spatial web.
+* A __domain type__, which indicates the particular role that the entity plays within the domain. This identifies how the entity is classified within the spatial web. Note that an entity can be defined by multiple different ontologies, but it _must_ have the domain type.
+
+An entity may have other other attributes, but these are not required:
+* A __location__, which identifies the entity's position in a state space (or __hyperspace__), relative to either the containing domain, or to an externally defined domain. If a domain exists solely as a vehicle for containment, then location is not specifically required, though it often contains additional state information that is not strictly speaking positional.
+* Zero or more __activities__, which provides the operational instructions for the entity in question. The structure of the activity is language independent and declarative.
+* Zero or more __style__ resources, which provides a mechanism for rendering the entity with different content types. _Please note, this has not been formally proposed yet, and may be removed_.
+* Zero or one __link__ references to an external domain. Some entities provide a link that can be activated through certain interfaces or affordances. This is a simple link, meaning it changes the context (domain) of the agent initiating the link without specific constraints, which is analogous to an HTTP standard hyperlink. More information about links will be covered in the subsection [Links](#links).
+

--- a/sources/sections/05-02-domain-entity-types.adoc
+++ b/sources/sections/05-02-domain-entity-types.adoc
@@ -1,0 +1,21 @@
+=== Domain Entity Types
+
+A __domain entity type__ is a specialization of an entity that incorporates additional capabilities. Within the Spatial Web, these extensions are defined using the Shape Constraint Language (SHACL), as a generalized schema language, with the mechanism for such extension covered in the section [Domain Entity Type Extensions](domain-entity-types.md), with link TBD.
+
+Currently several core extensions are defined: Place, Link, Domain, Sensor, Thing, Agent, and Assemblages, with others derivable from these. These are differentiated as follows:
+
+* A __place__ is defined roughly as a specific addressable location within a domain. Places define where an entity can be, and where they can't. Cf [Places](places.md) for more information.
+
+* A __link__ is a mechanism for navigating between both places (internal links) and domains (external links). It is the analog of a hypertext link in the HTTP world.Cf. [Links](links.md) for more information.
+
+* A __domain__ is a system of concern, and is effectively the partition of a given universe into a navigable area. Domains are where things happen. Cf [Domains](domains.md).
+
+* A __sensor__ is an abstraction of a camera, recording device, eyeball, etc. Its purpose is to provide a reference point of view for an entity within a domain (or of the domain itself).  Cf. [Sensors](sensors.md) for more information.
+
+* A __thing__ is defined as an entity that is directed by the system (the local spatial web daemon). Not that directed here means simply that it provides the motivating influence on the thing, not that it determines a things exact behaviors. In effect, both things and agents are "semi-autonomous" in that they have some (perhaps minimal) self-control, but they respond to outside influences. Things can be considered non-player characters, but they can also be structures, vehicles, animals, portals, and so forth. Cf. [Things](#things) for more details.
+
+* An __agent__ is defined as an entity that is directable by an outside (out of system) actor. Agents generally act as the eyes, ears, hands, and feet of the actor. It corresponds roughly to a character in a novel, play, or game, but in a more generalized fashion. Cf. [Agents](#agents) for more details.
+
+* An __assemblage__ is an aggregate structure of things, places, and agents. It is intended to model corporations, institutions, governments, and so forth, but it can also model physical or other composite structures.  Cf. [Assemblages](#assemblages) for more information.
+
+[[Previous]](entities.md) [[Next]](places.md)

--- a/sources/sections/05-03-places.adoc
+++ b/sources/sections/05-03-places.adoc
@@ -1,0 +1,182 @@
+=== Places
+
+==== General
+
+In the Spatial Web, places, not surprisingly have the position of prominance. It is defined as follows:
+
+____
+A __place__ within a domain is a *__unique__*, *__addressable__* state from the set of all possible states (a *__hyperspace__*) for that domain.
+____
+
+The definition of a place may sound rather formal and non-intuitive, but it comes about because of the mandate concerning the role of the spatial web as a way of describing both physical and conceptual spaces.
+
+____
+A place is __unique__ within a given domain if there are no other domains which have the same hyperspace configuration.
+____
+
+____
+A place is __addressable__ within a given domain if there is a specific set of keys or identifiers that collectively are also unique within that domain.
+____
+
+____
+A __hyperspace__ consists of the set of all valid places within a domain.
+____
+
+To make this definition clearer, consider a domain that represents a game (an instance) of _chess_. There are 66 potential _places_ where a given piece can be located - the 64 squares that make up an 8x8 chessboard, and two cache areas, one for each player, where pieces that are removed are located.
+
+![Chess Board, using algebraic notation and the initial starting position for the black pieces](https://upload.wikimedia.org/wikipedia/commons/b/b6/SCD_algebraic_notation.svg).
+
+This [board nomenclature](https://en.wikipedia.org/wiki/Algebraic_notation_%28chess%29) is considered canonical by [FIDE, the International Chess Federation](https://en.wikipedia.org/wiki/FIDE).
+
+Each of these places has a distinct identifier that makes up its address, and, within the scope of a particular game of chess, is considered unique. Note that the places here are not globally unique - the same position may be used across multiple games across multiple servers - but within the context of its domain, it IS unique.
+
+We can also make up notations for each of the two caches - White Cache (WC) and Black Cache (BC) for pieces that are outside the formal scope of the board but nonetheless represent the location of a specific piece (agent). If I move the White Queen (WQ) to e4, then that agent is now located in the place 4 units up from the White queen's side of the board and five units (e) from the left edge of the board.
+
+It is worth noting that the hyperspace here is ONLY these particular squares (or caches). You cannot go to position j17, because such a position, while plausable, does not exist within the set of all permissible places in the hyperspace.
+
+It is also worth noting that movement from place to place within a domain does not have to follow contiguity rules. The knight in particular is very constrained in where it can go (if the knight is on e4, than it can go to d6, f6, c3, c5, g3, g5, d2 or f2, but it cannot go to d4 or f4, which are contiguous to it ), but can also move over other pieces so long as the target place is not occupied by a piece of their own color.
+
+This is worth reiterating - a spatial web domain is not a perfect reproduction of the real world. The knight cannot move within its square (place) in this particular domain (though a representation could move within that square, it's not something that is considered in the model).
+
+To extend this, you can consider a hexagonal tiling of a space, as may be considered by a table top war game. The addressing in this space is more complex, because each hexagon has a particular index (address) that can be derived from some particular algorithm. The [H3 System](https://h3geo.org) system used by Uber is an illustration of such a tiling system on a sphere.
+
+![Hexagonal tiling](https://postgis.net/images/st_hexagongrid01.png)
+
+A place can also be defined in terms of an array of such tiling indices. These can in turn be hashed in some fashion to am irregular polygon. For instance, in the game of Risk, you can create such polygon that describe each of the "countries" in the game. Note that what is important in Risk is the movement from country (say Kamchatka) to country (Alaska).
+
+![The Risk World View](https://clairemcalpine.com/wp-content/uploads/2015/01/risk-map.png)
+
+In this particular map, the specific boundaries or definitions as geometries are less important than the underlying topology of the map (shown here specifically for North America)
+
+```mermaid
+graph TD
+
+    subgraph North America
+        Alaska(Alaska)
+        NWTerritory(NW Territory)
+        Greenland(Greenland)
+        Alberta(Alberta)
+        Ontario(Ontario)
+        Quebec(Quebec)
+        WesternUS(Western US)
+        EasternUS(Eastern US)
+        CentralAmerica(Central America)
+
+        Alaska --- NWTerritory
+        Alaska --- Alberta
+        Alaska --- Kamchatka_Asia
+
+        NWTerritory --- Greenland
+        NWTerritory --- Alberta
+        NWTerritory --- Ontario
+
+        Greenland --- Ontario
+        Greenland --- Quebec
+        Greenland --- Iceland_Europe
+
+        Alberta --- Ontario
+        Alberta --- WesternUS
+
+        Ontario --- Quebec
+        Ontario --- EasternUS
+        Ontario --- WesternUS
+
+        WesternUS --- EasternUS
+        WesternUS --- CentralAmerica
+
+        EasternUS --- CentralAmerica
+
+        CentralAmerica --- Venezuela_SA
+    end
+
+```
+
+This notion of identifying the places within a domain is useful in a number of ways because it forces thinking in terms of topology, rather than geography. There are ways of specifying the extents of particular place entities from a rendering standpoint (typically as sheets of polygons) but in most domains, dealing with the conceptual representation of a place is often far more important than dealing with a precise geographical distribution.
+
+In a topological view, places are connected via internal links (roughly analogous to the hypertext anchors or __&lt;a href="#foo"&gt;__ tags) to local links __&lt;a name="foo"&gt;__. These represent permissible states that a given agent can move to from a given place, absent any other constraining information. For instance, from Ontario, one can go to the Eastern or Western United States, Greenland, Quebec or Alberta, but you cannot go to Central America or Iceland directly without passing through an intervening country.
+
+Note that such a topological view also illustrates why places are entities. In this mode, a place is an entity that has some form of interaction. A place can be a hyperlink to another domain. For instance, one can imaging a scaled up version of Risk where different regions within the Ontario "country" have their own version of Risk. The game may be a subgame (a subdomain) of the current game, but the places involved are different.
+
+```mermaid
+graph TD
+
+    subgraph Ontario Region Cities
+        Toronto(Toronto)
+        Ottawa(Ottawa)
+        Montreal_QC(Montreal - Quebec)
+        Hamilton(Hamilton)
+        London(London)
+        Windsor(Windsor)
+        Kingston(Kingston)
+        Sudbury(Sudbury)
+        ThunderBay(Thunder Bay)
+        Winnipeg_MB(Winnipeg - Manitoba)
+
+        Toronto --- Hamilton
+        Toronto --- London
+        Toronto --- Kingston
+        Toronto --- Ottawa
+
+        Ottawa --- Montreal_QC
+        Ottawa --- Kingston
+
+        Hamilton --- London
+        Hamilton --- Windsor
+
+        London --- Windsor
+
+        Kingston --- Montreal_QC
+
+        Sudbury --- Toronto
+        Sudbury --- ThunderBay
+
+        ThunderBay --- Winnipeg_MB
+    end
+
+    %% Cross-provincial/state connections for context (optional, based on real-world travel)
+    Toronto --- Buffalo_NY(Buffalo - New York)
+    Windsor --- Detroit_MI(Detroit - Michigan)
+    ThunderBay --- Duluth_MN(Duluth - Minnesota)
+```
+
+This is a critical distinction between place and domain. The domain contains all of the potential place objects within a graph, but each place object may include a link to a domain that shows a deeper level of resolution. This is a pattern that occurs all the time, and is again illustrative of one of the central adages of the Spatial Web:
+
+> The map is not the territory. -- Alfred Korzybski
+
+> .. but it would like to be. -- Kurt Cagle
+
+This topological equivalency comes into play whenever there is a need to talk about routes, legs, river segments or similar things. It is intuitive to talk about a graph in which you have airports connected by routes, but the same graph can be inverted to talk about routes connected by airports. For instance, you can talk about the Seattle-San Francisco air route (which we can designate as SEA-SFO) and the San Francisco - Los Angeles route (SFO-LAX). SFO is a connection (a link) for the SEA-SFO and SFO-LAX routes.
+
+In this respect, routes and airports are both places - they represent specific states in a hyperspace, and as a consequence, their characteristics can be identified by the relevant properties for their specializization. An entity that is on a route domain, for instance, can talk about a location that's addressable as a distance indicator or time or percentage completed within the context, with a plane on that route able to determine its address relative to the path. Addresses do not need to be discrete, though it is frequently useful to do so especially when dealing with an observation based system.
+
+In the same vein, one can talk about places in street address notation. I have a house in Seattle, that house has a particular street address that can be decomposed into a set of related places because of composition, but the address space here is finite (if fairly large). Again, if the domain is a neighborhood, then the address space of the house places represents a typically small hyperspace, the set of all house places within the domain
+
+We tend to nest domain for organizational purposes (and a domain is as much an organizational structure as it is a physical space). For instance, is I have a domain of a city that is broken down into separate neighborhoods, the domain likely tells us nothing about the individual houses in those neighborhoods. You have to drill into the domain of a given neighborhood to get that level of information, with the neighborhood places in the city map then acting as hyperlinks to the respective subdomains.
+
+_Note that this model is somewhat different from other specific geospatial reference systems, in a few key ways. First is the fact that the address state space may have different reference coordinate equivalencies (H3, WGS-84-reference spheroid, relative coordinates and so forth), but these coordinates are only significant if the topological connections are insufficent.
+
+On a Risk game board, for instance, the hyperspace may be defined relative to a unit square, with each country then being given an position relative to the representation of that country's extent on the board. This may affect the user interface, but from the game's perspective, the position of the corresponding overlays is material only in that it correlates with the topological representations not the geometric one.
+
+This approach requires a certain degree of pre-planning. One reason that games are used as a metaphor is that they often allow for a significant reduction in the number of dimensions necessarily to capture a model. They also make goal achievement more feasible, because the agent or thing in the system can identify a goal and work with the information inherent in the topology rather than trying to intrinsically capture the specifics of how to achieve these goals.
+
+One additional note - topologies also work in higher dimensions and non-geospatial contexts. If you have an assembly line, for instance, the actual position of an object becomes secondary to where it is in terms of station and process. This is a key point, because once you move into a topological description of place, you can connect places via workflows (or even talk about conceptual stations that represent a place where you gain more information or perform specific actions), without having to deal with physical proximity as well.
+
+For instance, a physical description of the body can be rendered in one of three ways: the physical, using a tranverse plane coordinate system, can be helpful for developing models, but because bodies can be wildly different from individual to individual, most doctors make use of a taxonomic approach for describing the various systems - skeletal, musculature, pulminary, vascular, etc, then using relational maps and juncture points to indicate the specific connections. This anatomical hyperspace can identify not only location but also body system, and can be tied into diagnostics and drug pathway interaction graphs. Similarly, voxel type systems can be used to identify (with CRT partitioning) specific entities as aggregates of voxels, just as you would use hex tiling to do the same thing in two dimensions.
+
+This has one other consequence. One of the central challenges in building a domain is identifying boundaries. Fully contained boundaries can often be modeled as distinct domains, but even there, the shape of a given space is best identified by providing either a list of relevant tokens or a perimeter that can be used to identify containment.
+
+==== Landing Places
+
+A landing place is a place within a domain that is used to indicate where a given agent is placed (lands) when entering a domain without an explicit link to a place. This can be thought of as the "home" of the domain, and is indicated as a property of the domain. This corresponds roughly with the #top of an HTML page when it is rendered. Cf [Domains](domains.md) for more details.
+
+==== Entities As Places
+
+Typically links will take you from a place to another place, but it is possible to link to other entities. Such links will take you to the location of that entity. For instance, if you wanted to join a party (an [aggregation](aggregations.md)), then you could use the SWID of that aggregation to take you to where that party is located, even if that party moves around. See [links](links.md) for more details.
+
+
+==== Summary
+
+Places are a fundamental component of domains, but the two should not be confused. A domain is a context, a way of organizing information, and because this is the spatial web, a domain is frequently (but not always) associated with a place.
+
+ONe of the most important principles of working with places is in the recognition that topological relationships will likely be more important than direct geospatial relationships. The exact mechanism to determine how best to balance these two concerns is still TBD.
+

--- a/sources/sections/05-04-links.adoc
+++ b/sources/sections/05-04-links.adoc
@@ -1,0 +1,160 @@
+=== Links
+
+A link is a mechanism for moving both between places or other entities within a domain (local links) and to places or other entities within an external domain (external links).
+
+A link uses the [SWID](swids.md) of an entity as its target. When activated (through a specific activation activity), the controlling daemon will move the activator (typically an [agent](agents.md)) into the [domain](domain.md) of the target (typically a [place](places.md)) at the target's location. If only a domain is given, then the domain's [landing place](places.md=landing-places) within the domain will be targeted.
+
+If the link's target is not a place but some other form of entity, then the activiting agent will be placed at the [location of that entity within the domain](places.md=entities-as-places).
+
+
+[example]
+====
+For example, in a RISK game, there is a global RISK map domain that consists of multiple "countries".
+
+![The Risk World View](https://clairemcalpine.com/wp-content/uploads/2015/01/risk-map.png).
+
+Each country (a place) has an associated link to the domain for that country. When that link is activated by an agent (a particular player's general in the game) the agent is moved to the domain of that link, typically at the landing place for that domain.
+
+Note that there are two distinct actions that can be taken, selection and link traversal. If a place can be __selected__, it identifies that place as being part of an active set of places. If it is __activated__, then the link is traversed as described above.
+====
+
+==== Link Challenges and Keys
+
+A link may be associated with a challenge query. This query must be satisfied before the link is activated. Think of this as a lock on the link. The agent must have and apply an associated key for that lock before the agent can traverse the link. This metaphor is so persistent that it is easy to think of the entity containing the relevant link as a portal or door of some sort, though in general it is the link that powers this door.
+
+another analogy may be a turnstile for a subway station. In order to transition from the domain of the lobby to the domain of the station itself, you need to have a token or card. Without that token, you cannot make that transition - the turnstile won't turn.
+
+To carry forward with that metaphor, when boarding the train at the station, an agent has to wait until the train door opens before boarding. This is an example of a temporal link - it can only be traversed if a specific condition is met (the train is in the station and is at a complete stop, and is only open for a specific interval).
+
+Note that the hosting entity of the link can query the state of that link, and present a representation of that link's status to the corresponding agent. This is different from the way that HTTP links work.
+
+==== One Way and Bidirectional links
+
+There are no true bidirectional links within the spatial web. Instead, all links are unidirectional (one way), but there may be analogous entities (portals) for each link that provide the corresponding link back to the original place or entity.
+
+```mermaid
+graph LR
+    place1[Room 1]
+    place2[Room 2]
+    place1 -->|link to room2| place2
+    place2 -->|link to room1| place1
+```
+
+===== Neighborhoods
+
+The __neighborhood__ of a place is the set of all places that can be reached via links from that place. Note that they do not need to be contiguous (or even in the same domain), but they do have to be reachable via links. For instance, an elevator can be thought of as a place that connects multiple rooms, each on different floors.
+
+```mermaid
+graph LR
+    elevator
+    lobby
+    mezzanine
+    floor1Hallway
+    floor2Hallway
+    floor3Hallway
+    elevator <--> lobby & mezzanine & floor1Hallway & floor2Hallway & floor3Hallway
+```
+
+Here, the lobby, mezzanine, each floor's hallways are all part of the neighborhood for the elevator.
+
+The specific mechanism for choosing from a set of links is dependent upon the affordances offered by the reference place (or any entity located at that reference place). To facilitate this, each link has an optional order property that is used to indicate the order in which that link is presented.
+
+```
+Place:Elevator a Class:Place ;
+    Place:hasLink [
+        Link:hasPlace Place:Lobby ;
+        Link:order 1 ;
+    ],
+    Place:hasLink [
+        Link:hasPlace Place:Mezzanine ;
+        Link:order 2 ;
+    ],
+    Place:hasLink [
+        Link:hasPlace Place:Floor1Hallway ;
+        Link:order 3 ;
+    ],
+    Place:hasLink [
+        Link:hasPlace Place:Floor2Hallway ;
+        Link:order 4 ;
+    ],
+    Place:hasLink [
+        Link:hasPlace Place:Floor3Hallway ;
+        Link:order 5 ;
+    ].
+```
+
+Again, it is worth emphasizing here that this is a topologically, rather than physical, view of a particular space. Each of these places may be in their own separate closed domains, or they can be part of the same domain, but the effect is the same - it causes the agent to move through the topological graph of the places within that domain.
+
+==== Links as Movement
+
+This topological perspect presents some challenges that help to differentiate a Spatial Web domain from a web page document. The first is that there is no intrinsic "direction" within the Spatial Web, as compared to a document, which has a specific "reading order". To go from one place to another, your agent has to traverse a link.
+
+This means that moving from one place to another within a domain involves following a particular path of intervening places. This approach is straightforward and especially conducive to optimization of path traversals to minimize energy expenditure, though as the number of places goes up, so too does the complexity of such computations.
+
+In the real world, of course, we do not hop from place to place but move in a continuous fashion, and a robot or physical twin has to determine the "how" of traversal. Typically, this process lives in the interface between the virtual and physical twin.
+
+In general, this information may be stored in metadata that is associated with the link, but that is outside of the scope of the spatial web. For instance, a robot needs to move from the bottom of a hill to the top of a hill along a road. The link may indicate characteristics of the hill - its inclination in particular - but from the standpoint of the Spatial Web, this slope is a challenge that has to be met prior to achieving the key to allow the transition from one place (the bottom of the hill) to another (the top of the hill).
+
+In this case, the link challenge would be to solve a physics problem - is the weight of the robot, the power of the motor, and the inclination of the slope sufficient to reach the top, and are there any routes (sequences of places) that the robot can take if the slope is too challenging? If the problem is solved, then the robot goes ahead with the selected route, otherwise, the lock remains locked.
+
+For a sufficient large hyperspace, the mesh of potential paths can more closely represent a curve. For instance, the road may be treated as a space with a fairly high density of hexes, and rather than trying to tackle the road head-on in a linear fashion, it ascends the road as a series of switchbacks (much like a sailboat tacking against the wind).
+
+![Tacking](images/tacking.png)
+
+In the case where there is a physical twin bound to an agent, the link remains active until the physical twin indicates it has successfully completed the task, at which point it may update the metadata associated with the agent with physical coordinates that can be translated back into tiling.
+
+This means that in general the physical location of a tile will typically be its centrum, unless this is specifically overrriden with a centrum property.
+
+This analogy, by the way, also corresponds with non-Hilbert spaces, such as heat/pressure state regimes. In this case, the tiles represent specific regimes of behavior for the system, as the agent (or token) moves from one such state to the next. In the real world, these transitions are usually analog and may be subtle, but modeling these as a state diagram can be useful:
+```mermaid
+---
+config:
+   layout: elk
+---
+graph LR
+   perovskite[Perovskite]
+   ice[Ice]
+   liquidWater[Liquid Water]
+   steam[Steam]
+   plasma[Plasma]
+   perovskite <--> ice <-->liquidWater <--> steam <--> plasma
+   ice <--> steam
+```
+The agent's position across the hyperspace of places indicates what state the agent is in, where the agent can be seen as a marker for the current state.
+
+==== Specialized Link Properties
+
+A link can be set to be *__inactive__* and/or *__hidden__*. It's also possible to have *__nested links__*.
+
+===== Inactive Links
+An inactive link is visible, but can't be activated. Inactive links may serve the purpose of being descriptive (in a way similar to an inactive option in a select control in HTML works) or may be a divider.
+
+===== Hidden Links
+
+__Hidden Links__ are links that cause their containing entity to be invisible until a specific condition is met in the environment (such as the agent finding a magic scroll or having a certain power level).
+
+===== Nexted Links
+
+__Nested Links__ are links that point to other links. These are frequently used in menus, but they can also be used for things like double key authentication.
+
+==== Programmatic Links
+
+Ordinarily a link changes the location of the activating agent to a target SWID. Howevever, if a link does not have a target but does have an activity, then the activity is initiated once the initiating conditions are met, with the agent being passed as an argument.
+
+This is a mechanism by which activation of a link may introduce a change in the agent. For instance, dringing a magic potion (activating the link of that potion, may make the agent "stronger" in game terms ... or may turn them into a frog.
+
+Such a programmatic link also passes the linking entity. This can, for instance, inactivate the link once the potion is consumed, or make it hidden and inactive (which means that it can be removed from the domain).
+
+==== Links and Spatial Web Nodes
+
+Links are one of the few actions that can cross spacial web node boundaries. A SWID is a pointer to both a given entity or domain and its hosting corresponing SW Node. Activating the link initiates a sequence of steps:
+
+* Negotiate a challenge that checks to make sure that the agent can be moved.
+* Identify if the agent has a corresponding swid on the new system. If not, create one.
+* Copy the metadata for that agent in the graph of the new server.
+* Attach the agent to the indicated place within the new domain.
+* Notify the current server that the agent has been successfully replaced.
+* Deactivate the agent on the current node (not remove, just deactivate) if the transfer was successful, otherwise send a note to the actor of the current agent that the link failed.
+
+This is more complex than moving within a given node because the latter simply requires changing pointers.
+

--- a/sources/sections/05-05-sensors.adoc
+++ b/sources/sections/05-05-sensors.adoc
@@ -1,0 +1,40 @@
+=== Sensors
+
+The challenge that is faced with the Spatial Web is that what you see is not always what you get. In general, the way that a given domain is perceived will vary depending upon the observer - some observers will be capable of seeing a great deal, others, not much at all. In order to manage this, one particularly useful entity is the *__sensor__*.
+
+> A __sensor__ is a mechanism to get a particular point of view on a domain from the perspective of either a place, agent, assemblage or thing.
+
+The most obvious form of sensor is an _eyeball_, or the mechanical equivalent, the _camera_. However, this gives a fairly restrictive idea about what sensors are capable of.
+
+As an example, a very common sensor is a map-view sensor, which provides a representation of a particular domain from the perspective of an all encompassing eye (the map-view, or omniscient-view). This need not be a direct satellite view, but instead may be some form of boundary heat map drawing or icon view of entities within the domain. This may also generate an ESRI shape file, KML, GeoJSON, Geographic Markup Language, OSM, IDRISI Vectors, or similar format map resources.
+
+Similarly, a sensor may be a game-view, which shows the places in a game map with pieces (agents) located within those places. For instance, the game of RISK would generate such a game view that would be similar to a "standard" RISK board.
+
+Sensors are also not just visual. A sensor may provide a written or verbal description, data files, audio, image or video renditions and ao forth. The idea behind this is essential that a sensor provides information from multiple potential perspectives, across multiple filters, to generate multiple formats.
+
+Sensors ask sensory information about a thing or environment, and most specifically are used to answer the question? What is a description of this thing?
+
+Sensors are typically attached to an entity, with a single entity having multiple potential sensors (also known as a __sensor array__).
+
+Every entity has a state description graph, also known as a hyperspace represented as an n-dimensional hypercube (likely implemented as a W3C datacube). This represents the broadcast or public properties or features of the entity. The sensor array acts as a filter to perceive specific properties and interpret them.
+
+Sensors are basically data plugins - they are intended to provide some meaningful mapping of information coming from the entity state description graph and make that available in a consistent fashion.
+
+The exact mechanism for how sensors work is still under development, but runs roughly along the following lines:
+
+```mermaid
+---
+config:
+    layout: elk
+---
+graph TD
+    start([start])-->hstpReq[HSTP requests<br>View]
+    hstpReq-->iterate[Agent iterates<br>through other<br>entities' states]
+    iterate --> filter[Filter through<br>known sensor<br>Filters]
+    filter --> transform[Transform the<br>result into<br>requested format]
+    transform --> respond[Send to<br>output channel]
+    respond-->stop
+```
+In general, this output is performed as an HSTP request to get a description of state of either a given entity or the domain of entities.
+
+A similar loop occurs for each entity's internal update, but does not include the filter or transform, and typically does not respond to data outside of the hsml namespace. This is used in order to query the state of the surrounding graph in order to adjust movement to desired goals. This is handled by the internal udg daemon.

--- a/sources/sections/05-06-domains.adoc
+++ b/sources/sections/05-06-domains.adoc
@@ -1,0 +1,147 @@
+=== Domains and Contexts
+
+==== Definition of A Domain
+
+> __Definition.__ A domain is an object that identifies a context for an activity for or by a given agent at a specific place acting upon various things within that domain. Everything that happens within the UDG happens within a domain.
+
+A domain is a _system_. The domain provides the answers to a number of key questions about the system in question.
+* __Where?__. Where (what place) does the action within the system take place?
+* __How Is Space Defined?__ What are the relevant places of relevance within the system (it's hyperspace).
+* __How Is Spae Connected?__. How are things within the domain connected, and how are domains connected to other domains?
+* __What Happened?__. Is it possible to retrieve a history of what happened within the domain over time?
+* __What Kind?__. What classifications apply to the domain?
+* __Who?__. Which agents are participating within the domain?
+* __When?__. When does the activity take place within the context of the domain. This becomes especially critical for asynchronous events.
+* __What Happened?__. Is it possible to retrieve a history of what happened within the domain over time?
+* __How?__. What are the activities that can be accomplished within the domain, and how are these activated?
+* __Why?__. What are the goals or purposes of the domain, and what happens when those goals are achieved?
+
+
+
+Domains, unlike entities, are quasi-ephemeral. They exist within time (and by definition, space) but usually have a specific start time (or other condition) and end time (or other condition). Some domains may be fairly long-lasting, like a multiagent RPG that spans a number of different environments, while others may exist only for a session (or may be spun up or spun down, discussed below.
+
+In general, a domain has a schematic representation that can be extended from a core domain type. This identifies the relevant state variables and properties for the domains beyond the properties of the Domain base class. Domains are entities in that they have swids, but they are in effect system (or holonic) entities.
+
+==== Use Case: The Light Bulb Room
+
+> __Use Case.__ This is perhaps the simplest example of a domain. The Light Bulb room is a room with a single switch. The switch can be on or off. When the switch is on, the light is on. When the switch is off, the light is off.
+
+===== Where
+ The domain is in a __Place__ that we can call `Light Bulb Room =1`. Note that for the Domain, there was a template (or base class) called `<Light Bulb Room>`, specified via a schema language (for the moment, SHACL), that can both be used to create multiple instances, and to limit the number of instances so created.
+
+This handles the particular situation in which a given instance is tied to a digital twin as well as the situation where a single long-running domain may exist. For the light bulb room class (LBR), if the instance was tied to a physical room, then LBR=1 would need to persist between sessions, which would mean that the SWID for the room would be persistent for all agents that had permissions to access the domain.
+
+Note that Place in this case need only be a single value - the Room itself. The domain is the conceptual room, and there is no real reason to subdivide it into component places in this very simple model.
+
+===== How Is Space Defined
+
+The operational definition of a hyperspace is the set of all valid places within a domain. The spatial web (as currently defined) is a discrete spatial system. What this means in practice is that things are located in specific discrete Places, and within a domain, an agent moves from one such discrete Place to another through a link. A Place can describe the specific extent in other terms (H3, Geometric Tiles, ESRI geometries andso forth) but the domain determines which of those places are considered valid. This in turn reduces a potentially intractable geometric description into a graph-oriented topological description.
+
+===== How Is Space Connected
+
+In a __domain__, two or more __places__ are connected by __links__. A link is analogous to a hypertext link in HTTP. In each domain, there is typically at least one link from a source place to the __home place__ of the domain. When you "go to" a domain, you're agent is actually moving to the home place for that domain, unless another place is explicitly stated.
+
+In the Light Bulb Room, there is only one place defined for that domain, so if you are coming from the directory domain for the SW Node, then the directory will contain a link to the LBR=1 place. Unless there is a conditional lock on the link (you have to satisfy a test condition), you (or more specifically your agent) can generatlly backtrack across links through the client
+
+===== What
+
+This indicates the things that are bound to the room that are controllable from within the domain. In this case, there are two distinct things - a light switch and a lamp. By activating the light switch, you enable the lamp. By deactivating the light switch, you disable the lamp. In an analog system, of course, what the light switch does is turn power off to an electrical outlet, but this is an operational detail that is unimportant to the model.
+
+Note that there are a number of low level Things that will be generally subclassed. For instance, a lamp is a Meter that can take a value from a range of values (here [0,1]) A Toggle is a Thing that can take a Boolean value, and switch from one value to the other when activated. In short, many of these have a direct correspondance to HTML form components. These are detailed as part of the Activity specification, which is out of scope for this specification.
+
+===== What Kind
+
+A domain can be classified based upon a conceptual facet value tied to a specific classication facet (known as the Domain taxonomy). The specific facet can be given as a subproperty of this depending on the definition given within the associated shape.
+
+Everything is shape based rather than class based. This means that you can use combinations of facets to determine which property shapes apply to a given entity, which in turn means that you are not as dependent upon RDFS based supclass/subproperty inheritance.
+
+In the case of the Light Room =1,onw such classification might be IoTDevice, while another may be Purpose:Illumination or something similar.
+
+===== Who
+
+This indicates the agent(s) that are currently within the context of the room. There may be zero or more agents in the room at any given point, though the domain model could be set up to limit the number of agents that can occupy a given place at a certain time. This creates a crude physics.
+
+Note that in this model as well, there is no indication about the agents are, or what priorities they have. In general, if one agent turns the light on and the other turns it off, then the system will reflect the current state from the last activity that occurred.
+
+Agents can move from one place to another (see [Places](places.md) for more information).
+
+===== When
+
+Each domain has a clock. Typically, such clocks can be defined in terms of a Spatial Web Node chronometer that is specific to the host (to the extent that in many cases, the domain can refer to a specific "System Clock", which is the default chronometer when not otherwise supplied). Note that this is used primarily to control timing and action within system on the part of autonomous entities, and in general is NOT synched from one node to the next. A chronometer is of type Entity:Thing.
+
+Also please note that the chronometer is not technically part of hyperspace. If, for instance, you had a relativity simulation, then the time component of such a transformation would be treated as a coordinate in the hyperspace system (if you are doing Lorenz Transformations, for instance), but this is only peripherally related to the domain chronometer. The chronometer is, however, a key part of maintaining a domain history (see [What Happened?](=whatHappened).
+
+===== What Happened
+
+Each domain manages its own queue indicating relevant state change reports that are updated as part of the activity. This becomes the history of the domain. In this case, every time that the switch is flipped, the context of the domain for those things maintaining a history get written to the queue, indicating who initiated the action and what the state of the light (the meter) was at the time. This effectively creates a recording of the session, and in theory should be transformable to reproduce the state transitions of the system.
+
+> __Editor's Note__. The depth of the queue will obviously be dependent upon system resources, and may be in a condensed serialized format. The exact mechanism for how this works is still TBD.
+
+===== How
+
+One of the roles of the chronometer is to indicate when a given domain should check to see if an expressed contextual configuration is in place (typically by querying the graph) and if it is, to then cause some activity within the domain. These are domain specific, such as expressing representations of the domain to an external channel.
+
+> __Editor's Note__: The details of Activity are still being worked out, and will be updated accordingly here.
+
+===== Why
+
+Most domains have objectives and goals. A remote drone domain, for instance, exists to get the drone to a target, perform a function, and hopefully return safely. These objectives typically will put the domain into a different state (Reset, Archive, Delete, etc.) In a game, these are the conditions that end the game and determine the winner. In a story, this is The End. In a device controller, this the termination of the updates to the devices in question. When the domain is instantiated, the why is set up as an end condition and is evaluated as part of the processing cycle for the domain.
+
+==== Domains, Links and Hyperspaces
+
+Places have an obvious containment relationship - Earth is made up of continents, which are made up of ountries, which are made up of cities, which are made up of even smaller divisions.
+
+Domains are not places, though they might appear to be at first glance. A domain has a place property that can in fact refer to multiple places. For instance, one can make up a domain of Red States, a domain of Blue States, and possible a domain of Purple States in the United States. It also has a Home place property that acts as a default when the domain is referenced as the target of a link - this can be thought of as the equivalent of a landing page (or index.html in HTTP terms).
+
+This creates an interesting phenomenon. The most common form of link within the UDG is a link from one place to another place typically within the same domain. The links exist primarily for agents, but an agent may also have the ability to carry certain things from one place to another within a given domain.
+
+This is different behavior from the way that a link works in HTTP. There, activating a link sends the browser (the user agent) to a new address. With HSTP, activating a link will typically move the agent to a new Place within the domain. In a game environment such as Monopoly, this basically moves the agent's token to the new place (say from Pennsylvania Ave to Boardwalk). In a game like chess, each player in effect controls sixteen agents, one for each chess piece on their side, though they can only control one such agent at any given turn.
+
+This also raises an interesting quandry. Links can be contextual, and are also not necessarily contiguous. The valid links for a knight agent, for instance, is L shaped, and it can jump over adjacent squares, but can't jump outside of the boundaries of the board. The bishop can only move across diagonals, and only until it encounters a piece of the opposite's side (a capture) or a piece of the active side (a block). This indicates that the hyperspace of a domain is topological.
+
+==== The Topological Hyperspace
+
+A topological space is one in which direct physical constraints are minimized in favor of conceptual ones. In effect, a domain consists of a set of places, each of which is a conceptual node connected by links. The set of all places that are traversable within the graph makeup the hyperspace for that domain, with the links in turn controlling access from one place to another within the domain.
+
+```mermaid
+---
+config:
+    layout: elk
+---
+graph LR
+    r1[Room1]
+    r2[Room2]
+    r3[Room3]
+    r4[Room4]
+    r5[Room5]
+    r6[Room6]
+    r1 -->|=9758;| r2
+    r1 -->|=9919;| r3
+    r2 -->|=9919;| r4
+    r3 -->|=9758;| r4
+    r2 -->|=9758;| r3
+    r4 -->|=9719;| r5
+    r4 -->|=9758;| r6
+```
+In this case, the hyperspace for the domain consists of six "rooms", each connected by links of various types:
+* Pointers (&=9758;) represent open links - an agent can move from one room to the next freely.
+* Keys (&=9919;) represent locked links - the agent needs some form of key to open the link and move to the next room.
+* Finally, clocks (&=9719;) represents conditional locks - an external condition (such as a store being closed for the night) must be met before traversal can happen.
+
+This is an example of a topological domain. It consists of six Places, but each Place does not necessarily have to represent a physical location in the real world. Instead, the place is simply a scope for containment. It could represent stations in an assembly line, steps in a process, a detailed internal representation of a given subsystem, and so forth.
+
+The notion of linked places can be used to create an alternative for managing holonic viewpoints. For instance, if you have a place that represents a car, there is a link (perhaps the button that releases the latch that holds the hood closed), which will then take you to an entry place ("room") that contains the engine compartment, and that lets you in turn dig deeper into the engine, the battery, the alternator and so forth.
+
+This approach has a number of key advantages - first - you can control access to various subsystems because they are topological just places within the overall domain that are constrained by the links that connect them. Because links are contextual, you can only access certain subsystem if either you (or your agent) have the relevant key or some external condition is in force.
+
+This also relieves the Spatial Web of having to do heavy extensive physical mapping. This can be added back in, either by increasing the number of places to better represent a tighter partitioning of the space, or by providing more subtle links to create more neighborhoods (these are essentially equivlent actions).
+
+The hyperspace of the domain then becomes the set of all places within that domain. This solves another problem that a more physical realization introduces - determining whether you are at the edge of, or out of the boundaries of, a physical space. In a topological model, if the place is not in the domain, then it is not accessible by ANY agent.
+
+==== Topological vs Continuous Hyperspace
+
+The topological view is one where a domain consists of a finite number of discrete places, each with its own SWID.
+
+==== Domains and Domain Templates
+
+> __Definition.__ A __domain template__ is an *__activity__* that generates a domain.

--- a/sources/sections/05-building-blocks.adoc
+++ b/sources/sections/05-building-blocks.adoc
@@ -1,0 +1,14 @@
+== Building blocks
+
+include::05-01-entities.adoc[]
+
+include::05-02-domain-entity-types.adoc[]
+
+include::05-03-places.adoc[]
+
+include::05-04-links.adoc[]
+
+include::05-05-sensors.adoc[]
+
+include::05-06-domains.adoc[]
+

--- a/sources/sections/annex-bibliography.adoc
+++ b/sources/sections/annex-bibliography.adoc
@@ -1,0 +1,155 @@
+
+[appendix,obligation=informative]
+== Bibliography
+
+[bibliography]
+=== Bibliography
+
+// Standards
+
+// ------------------------------------
+
+// IEEE documents
+
+// ------------------------------------
+
+* [[[IEEE_730_2014,IEEE Std 730-2014]]]
+
+* [[[IEEE_802.1AR_2018,IEEE Std 802.1AR-2018]]]
+
+* [[[IEEE_1589_2020,IEEE Std 1589-2020]]]
+
+* [[[IEEE_1874_2013,IEEE Std 1874-2013]]]
+
+* [[[IEEE_2660.1_2020,IEEE Std 2660.1-2020]]]
+
+* [[[IEEE_2755_2017,IEEE Std 2755-2017]]]
+
+
+// ------------------------------------
+
+// ISO/IEC documents
+
+// ------------------------------------
+
+* [[[ISO_19135_1_2015,ISO 19135-1:2015]]]
+
+* [[[ISO_22300_2021,ISO 22300:2021]]]
+
+* [[[ISO_37101_2016,ISO 37101:2016]]]
+
+* [[[ISO_IEC_12113_2022,ISO/IEC 12113:2022]]]
+
+* [[[ISO_IEC_TR_18121_2015,ISO/IEC TR 18121:2015]]]
+
+// ------------------------------------
+
+// ISO/IEC/IEEE documents
+
+// ------------------------------------
+
+* [[[ISO_IEC_IEEE_21451-1_2010,ISO/IEC/IEEE 21451-1:2010]]]
+
+* [[[ISO_IEC_IEEE_24765_2017,ISO/IEC/IEEE 24765:2017]]]
+
+
+// ------------------------------------
+
+// IEC Electropedia: The World's Online Electrotechnical Vocabulary
+
+// ------------------------------------
+
+// 20240208 iev autofetch not resolving, using manual option
+// * [[[ievterms,IEV]]]
+
+* [[[ievterms_m,1]]]
+span:organization[International Electrotechnical Commission (IEC)]
+span:title[IEC Electropedia: The World's Online Electrotechnical Vocabulary]
+span:type[website]
+span:date[2024]
+span:uri[https://www.electropedia.org/]
+
+
+// ------------------------------------
+
+// OGC documents
+
+// ------------------------------------
+
+
+* [[[ogc_citygml,OGC 20-010]]], OGC OGC City Geography Markup Language (CityGML) Part 1: Conceptual Model Standard
+
+* [[[ogc_gml,OGC 07-036]]], OpenGIS Geography Markup Language (GML) Encoding Standard
+
+// ------------------------------------
+
+// W3C documents
+
+// ------------------------------------
+
+* [[[w3c_respon_spatial,W3C responsible-use-spatial]]]
+
+* [[[w3c_rdf,W3C rdf-concepts]]]
+
+// IETF documents
+
+* [[[http3_rfc,IETF RFC 9114]]]
+
+// Groups
+
+* [[[H3_geo_functions,1]]]
+span:organization[Apache Software Foundation]
+span:title[databricks--H3 geospatial functions]
+span:type[website]
+span:date[2024]
+span:uri[https://docs.databricks.com/en/sql/language-manual/sql-ref-h3-geospatial-functions.html]
+
+* [[[didcomm,1]]],
+span:title[Decentralized Identity Foundation: DIDComm Messaging Working Group]
+span:type[website]
+span:uri[https://github.com/decentralized-identity/didcomm-messaging]
+
+* [[[mit_rules_as_code,1]]],
+span:organization[MIT Computational Law]
+span:surname[Morris], span:initials[J.]
+span:title[Blawx: Rules as Code Demonstration]
+span:type[webresource]
+span:uri[https://law.mit.edu/pub/blawxrulesascodedemonstration/release/1]
+
+* [[[nextgen_de,1]]],
+span:surname[Goodchild], span:initials[M.]
+span:surname[Guo], span:initials[H.]
+span:surname[Annoni], span:initials[A.]
+span:surname[Bian], span:initials[L.]
+span:surname[de Bie], span:initials[K.]
+span:surname[Campbell], span:initials[F.]
+span:surname[Craglia], span:initials[M.]
+span:surname[Ehlers], span:initials[M.]
+span:surname[van Genderen], span:initials[J.]
+span:surname[Jackson], span:initials[D.]
+span:surname[Lewis], span:initials[A. J.]
+span:surname[Pesaresi], span:initials[M.]
+span:surname[Remetey-Fülöpp], span:initials[G.]
+span:surname[Simpson], span:initials[R.]
+span:surname[Skidmore], span:initials[A.]
+span:surname[Wang], span:initials[C.]
+span:surname[Woodgate], span:initials[P.]
+span:title[Next-generation Digital Earth]
+span:type[inproceedings]
+In: span:in_title[Proceedings of the National Academy of Sciences of the United States of America]
+vol. span:volume[109],
+issue. span:issue[28],
+span:date[2012],
+pp. span:pages[11088-11094]
+doi: span:uri.doi[10.1073/pnas.1202383109]
+
+* [[[manual_of_de,1]]],
+span:surname[Goodchild], span:initials[M.]
+span:surname[Guo], span:initials[H.]
+span:surname[Annoni], span:initials[A.]
+span:type[book]
+span:title[Manual of Digital Earth]
+pp. span:pages[852]
+span:date[2019],
+doi: span:uri.doi[10.1007/978-981-32-9915-3]
+

--- a/sources/sections/annex-swf_authors_reviewers.adoc
+++ b/sources/sections/annex-swf_authors_reviewers.adoc
@@ -1,0 +1,33 @@
+[appendix,obligation=informative]
+
+[heading=clause]
+
+== Participants
+
+The list below includes persons who participated in the Spatial Web Foundation Working Group that developed this Specification and who consented to appear on this list.
+
+Mahault Albarracin +
+Flores Bakker +
+Scott Carroll +
+Tom De Block +
+Bastiaan den Braber +
+Geert Devos +
+Jason Fox +
+Karl Friston +
+Jacqueline Hynes +
+Alex Kiefer +
+Martin Laskowski +
+Sarah Grace Manski +
+Dan Mapes +
+George Percivall +
+Christine Perey +
+Capm Petersen +
+Reese Plews +
+Maxwell Ramstead +
+Gabriel René +
+Dan Richardson +
+Mikel Salazar +
+Philippe Sayegh +
+Prasaanth Sridharan +
+Toby St Clere Smithe +
+Alec Tschantz


### PR DESCRIPTION
This is in response to the request from @cperey and @percivall to create a Metanorma version of the document in this repository.

This repository contains various topics so I was uncomfortable suggesting a single TOC that encompasses the entire document. I believe @kurtcagle (nice to meet you!) would be in the best position to doing so.

The root source of the document is at `sources/document.adoc`. 

So far I have done the following:

* Set up the repository as per [IEEE P2874](https://github.com/Spatial-Web-Foundation/SWF-Corpus_and_IEEEP2874) which provides an IEEE document as output
* GitHub Actions workflows are properly setup.
* Clauses 1-3 are mandatory to IEEE in a conforming format. All you need is to fill in content relevant to this document.
* The Bibliography (mandatory) and an "SWF Acknowledgment" annex (optional) is included here, with sample content.
* Clause 4 is empty for your usage.
* Combined the content of these Markdown files into Clause 5 "Building blocks", `05-building-blocks.adoc`. It links to:
```
entities.md => 05-01-entities.adoc  
domain-entity-types.md => 05-02-domain-entity-types.adoc
places.md => 05-03-places.adoc
links.md => 05-04-links.adoc
sensors.md => 05-05-sensors.adoc
domains.md => 05-06-domains.adoc
```

Please refer to the [IEEE P2874](https://github.com/Spatial-Web-Foundation/SWF-Corpus_and_IEEEP2874) README on how to build.

@cperey @percivall please let me know if there is anything else myself or our team could help with here. Thanks!
